### PR TITLE
Reworked clear opcache step

### DIFF
--- a/include/opcache.php
+++ b/include/opcache.php
@@ -2,6 +2,11 @@
 namespace Deployer;
 
 /**
+ * Configuration
+ */
+set('php_sock_path', '~/run/*.php-fpm.sock,/var/run/$(whoami)-remi-safe-php*.sock');
+
+/**
  * Tasks
  */
 desc('PHP Opcache flush');
@@ -15,7 +20,7 @@ task('php:opcache:flush', function() {
     fi');
 
     run('
-    for sock in {~/run/*.php-fpm.sock,/var/run/$(whoami)-remi-safe-php*.sock}; do
+    for sock in {{{php_sock_path}}}; do
         if [ -S $sock ]; then
             ~/cachetool/bin/cachetool opcache:reset --fcgi=$sock && \
             echo "Opcache was cleared (php sock is $sock)"

--- a/include/opcache.php
+++ b/include/opcache.php
@@ -14,10 +14,9 @@ task('php:opcache:flush', function() {
 
     // Php socket to clear opcache can be located in different places
     // on different servers, just add your paths, if needed
-    run('
-    if [ ! -d ~/cachetool ]; then
-        {{bin/composer}} create-project gordalina/cachetool ~/cachetool
-    fi');
+    if (test('[ ! -d ~/cachetool ]')) {
+        run('{{bin/composer}} create-project gordalina/cachetool ~/cachetool');
+    }
 
     run('
     for sock in {{{php_sock_path}}}; do

--- a/include/opcache.php
+++ b/include/opcache.php
@@ -9,7 +9,10 @@ task('php:opcache:flush', function() {
 
     // Php socket to clear opcache can be located in different places
     // on different servers, just add your paths, if needed
-    run('[ ! -d ~/cachetool ] && composer create-project gordalina/cachetool ~/cachetool');
+    run('
+    if [ ! -d ~/cachetool ]; then
+        {{bin/composer}} create-project gordalina/cachetool ~/cachetool
+    fi');
 
     run('
     for sock in {~/run/*.php-fpm.sock,/var/run/$(whoami)-remi-safe-php*.sock}; do

--- a/include/opcache.php
+++ b/include/opcache.php
@@ -2,28 +2,20 @@
 namespace Deployer;
 
 /**
- * Configuration
- */
-set('php_version', function() {
-    return run('{{bin/php}} -r "echo phpversion();"');
-});
-set('bin/curl', function() {
-    return locateBinaryPath('curl');
-});
-
-/**
  * Tasks
  */
 desc('PHP Opcache flush');
 task('php:opcache:flush', function() {
-    $cacheToolVersion = version_compare(get('php_version'), '7.2', '>=') ? '' : '-3.2.1';
 
     // Php socket to clear opcache can be located in different places
     // on different servers, just add your paths, if needed
+    run('[ ! -d ~/cachetool ] && composer create-project gordalina/cachetool ~/cachetool');
+
     run('
-    {{bin/curl}} -s http://gordalina.github.io/cachetool/downloads/cachetool'.$cacheToolVersion.'.phar -o cachetool.phar
-    chmod +x cachetool.phar
     for sock in {~/run/*.php-fpm.sock,/var/run/$(whoami)-remi-safe-php*.sock}; do
-        if [ -S $sock ]; then ./cachetool.phar opcache:reset --fcgi=$sock; fi
+        if [ -S $sock ]; then
+            ~/cachetool/bin/cachetool opcache:reset --fcgi=$sock && \
+            echo "Opcache was cleared (php sock is $sock)"
+        fi;
     done');
 });


### PR DESCRIPTION
* `cachetool` now is downloaded as composer package - so, we don't need to check php version (composer itself does it)
* added message if opcache was cleared successfully
* php sock path was moved to variable `php_sock_path` - now it can be set through host configuration if needed