### PR TITLE
Force symlink creations

### DIFF
--- a/deploy.php
+++ b/deploy.php
@@ -88,7 +88,7 @@ desc('Magento2 create symlinks');
 task('magento:create:symlinks', function() {
     cd('{{release_path}}');
     foreach (get('symlinks') as $key => $value) {
-        run('ln -s '.$value.' '.$key);
+        run('ln -sf '.$value.' '.$key);
     }
 });
 


### PR DESCRIPTION
The fix solves an issue in the deployments, when some project folder should be linked **inside** shared folder.

For example, there's such structure of a project:
- wp (shared)
- wp-content (not shared)

Once all deploy things are done, we need to have symlink `wp/wp-content -> wp-content` - and that's fine with small adjustments in deploy configuration (which is `hosts.yml`):

`+symlinks: wp/: ../wp-content`

The problem is after first deployment the `wp` folder will already have symlink to `wp-content`, which causes failing all next deployments during creating symlinks step:

```
[master] > cd ~/deploy/releases/16 && (ln -s ../wp-content wp/)
[master] < ln: failed to create symbolic link 'wp/wp-content': File exists
```

With `--force` (-f) option the symlink will be overridden if it exists - and the command will be ran without errors.