### PR TITLE
TASK-20486834 - rework patch apply step

### DIFF
--- a/deploy.php
+++ b/deploy.php
@@ -61,7 +61,7 @@ task('magento:apply:patches', function() {
     run('
     for patch in patch/*.patch; do
         if [ -f $patch ]; then
-            {{bin/git}} apply -v $patch || echo "##[error]The patch $patch is not applicable";
+            {{bin/git}} apply -v $patch || printf "##[%s]The patch $patch is not applicable" "error";
         fi;
     done');
 });

--- a/deploy.php
+++ b/deploy.php
@@ -61,7 +61,7 @@ task('magento:apply:patches', function() {
     run('
     for patch in patch/*.patch; do
         if [ -f $patch ]; then
-            {{bin/git}} apply -v $patch || exit $?
+            {{bin/git}} apply -v $patch || echo "##[error]The patch $patch is not applicable";
         fi;
     done');
 });

--- a/deploy.php
+++ b/deploy.php
@@ -57,13 +57,13 @@ set('m2_version', function() {
  */
 desc('Magento2 apply patches');
 task('magento:apply:patches', function() {
+    cd('{{release_path}}');
     run('
-    cd {{release_path}}
-    if [ -d patch ]; then
-        for patch in patch/*.patch; do
-            {{bin/git}} apply -v $patch
-        done
-    fi');
+    for patch in patch/*.patch; do
+        if [ -f $patch ]; then
+            {{bin/git}} apply -v $patch || exit $?
+        fi;
+    done');
 });
 
 desc('Magento2 dependency injection compile');


### PR DESCRIPTION
2 issues have been solved here:
- if the folder `patch` was empty, `git apply` received `patch/*.patch` as a patch file and failed => whole deployment failed. That was fixed by checking exists the patch file or not, before applying.
- earlier if applying of a patch returned wrong exit code (> 0), it can be skipped - it's mistake, if a patch can't be applied for some reason the deployment must be failed too.