### PR TITLE
Restoring opcache

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -8,20 +8,31 @@
     "packages": [
         {
             "name": "deployer/deployer",
-            "version": "v7.3.3",
+            "version": "v7.5.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/deployphp/deployer.git",
-                "reference": "3535bdb2f6360662bd95f6e26fce31dbc269af64"
+                "reference": "448761221383877d61bed6700805001f872c0ad3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/deployphp/deployer/zipball/3535bdb2f6360662bd95f6e26fce31dbc269af64",
-                "reference": "3535bdb2f6360662bd95f6e26fce31dbc269af64",
+                "url": "https://api.github.com/repos/deployphp/deployer/zipball/448761221383877d61bed6700805001f872c0ad3",
+                "reference": "448761221383877d61bed6700805001f872c0ad3",
                 "shasum": ""
             },
+            "require": {
+                "ext-json": "*",
+                "php": "^8.0|^7.3"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^3.64",
+                "pestphp/pest": "^3.3",
+                "phpstan/phpstan": "^1.4",
+                "phpunit/php-code-coverage": "^11.0",
+                "phpunit/phpunit": "^11.4"
+            },
             "bin": [
-                "dep"
+                "bin/dep"
             ],
             "type": "library",
             "notification-url": "https://packagist.org/downloads/",
@@ -47,16 +58,16 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-11-07T10:27:12+00:00"
+            "time": "2025-02-10T14:27:00+00:00"
         }
     ],
     "packages-dev": [],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": [],
-    "platform-dev": [],
+    "platform": {},
+    "platform-dev": {},
     "plugin-api-version": "2.6.0"
 }

--- a/deploy.php
+++ b/deploy.php
@@ -183,6 +183,8 @@ task('deploy', [
     'magento:create:symlinks',
     'magento:cache:flush',
     'deploy:symlink',
+    'php:opcache:flush',
+    'magento:di:compile',
     'deploy:unlock',
     'deploy:cleanup',
     'deploy:success'


### PR DESCRIPTION
Restoring opcache and adding in another di:compile.

I don't feel good about this. It further slows down the deployment process (which is already slow) however constantly failed deployments are much worse than that. 

I *think* one of the hidden issues is to do with the file paths. I think in the process before we were flushing opcache when it was in the releases folder and recompiling but at the end we then update the symlink which means the path comes back to ~/deploy/current/class_path.

Because of this I think we have to clear it only after the symlink is completed (and even then I'm not 100% sure as we are running it still from the releases folder not the ~/deploy/current folder which I'm guessing it where we actually always run it from when we are fixing it manually. 