### PR TITLE
Add skip_lfs option to skip Git LFS files during deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /.idea
 /vendor
+/docs
+CLAUDE.md

--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ You need to follow this simple steps to integrate in your project:
 
 ### Git LFS
 
-By default, Git LFS files are skipped during deployment. This speeds up deployments when LFS is used for files not needed on servers (e.g., local database backups).
+By default, Git LFS files are skipped during deployment (`skip_lfs: true`). This prevents large LFS objects (e.g., local database backups) from being downloaded to servers, saving both deployment time and disk space.
 
-To enable LFS file downloads for a specific host, add to your _hosts.yml_:
+To disable this, set `skip_lfs: false` in your _hosts.yml_:
 
 ```yaml
 production:
@@ -34,6 +34,8 @@ production:
   remote_user: deploy
   skip_lfs: false
 ```
+
+**Note:** The `skip_lfs` option uses `set('env', ...)` to configure the `GIT_LFS_SKIP_SMUDGE` environment variable. If your project needs additional environment variables, add them inside the same closure in _deploy.php_ rather than calling `set('env', ...)` separately, which would overwrite the LFS setting.
 
 ## Related links:
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,21 @@ You need to follow this simple steps to integrate in your project:
 
 7. Push a commit to dev/test/master branch!
 
+## Configuration
+
+### Git LFS
+
+By default, Git LFS files are skipped during deployment. This speeds up deployments when LFS is used for files not needed on servers (e.g., local database backups).
+
+To enable LFS file downloads for a specific host, add to your _hosts.yml_:
+
+```yaml
+production:
+  hostname: prod-server
+  remote_user: deploy
+  skip_lfs: false
+```
+
 ## Related links:
 
 https://deployer.org

--- a/deploy.php
+++ b/deploy.php
@@ -35,7 +35,7 @@ set('asset_locales', 'en_US en_IE');
 
 // Skip Git LFS files during clone - these are typically dev database backups not needed on servers
 set('skip_lfs', true);
-add('env', function () {
+set('env', function () {
     if (get('skip_lfs', true)) {
         return ['GIT_LFS_SKIP_SMUDGE' => '1'];
     }

--- a/deploy.php
+++ b/deploy.php
@@ -33,6 +33,15 @@ set('repo_path', 'src');
 set('keep_releases', 3);
 set('asset_locales', 'en_US en_IE');
 
+// Skip Git LFS files during clone - these are typically dev database backups not needed on servers
+set('skip_lfs', true);
+add('env', function () {
+    if (get('skip_lfs', true)) {
+        return ['GIT_LFS_SKIP_SMUDGE' => '1'];
+    }
+    return [];
+});
+
 set('is_hyva_project', 0);
 set('hyva_path', 'app/design/frontend/Aonach/hyva');
 set('bin/npm', function () {


### PR DESCRIPTION
## Summary
- Add `skip_lfs` config option (default: `true`) that sets `GIT_LFS_SKIP_SMUDGE=1` env var for git operations during deployment
- Prevents downloading LFS files (typically local dev database backups) that aren't needed on servers
- Can be overridden per-host in `hosts.yml` with `skip_lfs: false`

## Test plan
- [ ] Deploy to dev with `-vvv` and verify `GIT_LFS_SKIP_SMUDGE='1'` appears in the export statements during `deploy:update_code`
- [ ] Confirm LFS pointer files remain as pointers in the release directory
- [ ] Test override by setting `skip_lfs: false` on a host and verifying LFS files are downloaded

🤖 Generated with [Claude Code](https://claude.com/claude-code)