### PR TITLE
Add vendor copy from previous release to speed up deploys

### DIFF
--- a/deploy.php
+++ b/deploy.php
@@ -180,6 +180,10 @@ task('magento:cache:flush', function () {
     run('{{bin/php}} {{release_path}}/bin/magento cache:enable');
 });
 
+// Copy directories from previous release to speed up composer install
+// Enable per-host by setting copy_dirs: ['vendor'] in hosts.yml
+before('deploy:vendors', 'deploy:copy_dirs');
+
 desc('Deploy your project');
 task('deploy', [
     'deploy:prepare',

--- a/hosts.yml
+++ b/hosts.yml
@@ -19,6 +19,9 @@ hosts:
     shared_dirs: # shared directories between releases | default: pub/media, var/log
       - var/composer_home
 
+    copy_dirs: # copy from previous release to speed up composer install
+      - vendor
+
   test:
     hostname: test-host
     remote_user: test-user


### PR DESCRIPTION
## Summary
- Hook `deploy:copy_dirs` to run before `deploy:vendors`, copying `vendor/` from the previous release
- Only enabled on `dev` host for testing — test and master continue with clean installs
- Expected to significantly reduce `deploy:vendors` time (currently ~130s for 597 packages)

## Configuration
Enable per-host in `hosts.yml`:
```yaml
copy_dirs:
  - vendor
```

## Test plan
- [ ] Deploy to dev and compare `deploy:vendors` timing against 130s baseline
- [ ] Verify `composer install` runs successfully after vendor copy
- [ ] Confirm no stale packages remain after a dependency change

🤖 Generated with [Claude Code](https://claude.com/claude-code)